### PR TITLE
Add support to send logstash events to multiple endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Added support to send to multiple endpoints
 
 ## [0.1.0] - 2016-08-10
 - changed sensu-plugin dependecy from `= 1.2.0` to `~> 1.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## [Unreleased]
+## [1.0.0] - 2017-01-23
 - Added support to send to multiple endpoints
 
 ## [0.1.0] - 2016-08-10

--- a/README.md
+++ b/README.md
@@ -17,11 +17,20 @@
 ```
 {
   "logstash": {
-    "server": "redis.example.tld",
-    "port": 6379,
+    "endpoint": [
+      {
+        "address": "host1.example.tld",
+        "port": 5000,
+        "output": "redis"
+      },
+      {
+        "address": "host2.example.tld",
+        "port": 5001,
+        "output": "logstash"
+      }
+    ],
     "list": "logstash",
     "type": "sensu-logstash",
-    "output": "redis",
     "custom": {
       "thisFieldWillBeMergedIntoTheTopLevelOfOutgoingJSON": {
         "metadata": "some metadata",

--- a/lib/sensu-plugins-logstash/version.rb
+++ b/lib/sensu-plugins-logstash/version.rb
@@ -1,7 +1,7 @@
 module SensuPluginsLogstash
   module Version
-    MAJOR = 0
-    MINOR = 1
+    MAJOR = 1
+    MINOR = 0
     PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
There is a need to send Logstash events to more than one endpoint, this change will allow you to specify several different endpoints (Address, host, output type), all of which will be looped through and the event sent.

This is an alternative, hopefully more lightweight, method to having multiple logstash handlers running for every event, which could become quite resource intensive.

#### Known Compatablity Issues
Breaking change.
The Logstash json will need to be updated in conjuction with this handler, else the handler will fail to run.

