### PR TITLE
Update json gem dependency to be less restrictive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [0.1.1] - 2017-03-15
+- changed json dependency from '= 1.8.3' to '< 2.0.0'
+
 ## [0.1.0] - 2016-08-10
 - changed sensu-plugin dependecy from `= 1.2.0` to `~> 1.2`
 - added TCP socket as an output option

--- a/lib/sensu-plugins-logstash/version.rb
+++ b/lib/sensu-plugins-logstash/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsLogstash
   module Version
     MAJOR = 0
     MINOR = 1
-    PATCH = 0
+    PATCH = 1
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-logstash.gemspec
+++ b/sensu-plugins-logstash.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsLogstash::Version::VER_STRING
 
-  s.add_runtime_dependency 'json',         '1.8.2'
+  s.add_runtime_dependency 'json',         '< 2.0.0'
   s.add_runtime_dependency 'redis',        '3.2.1'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
The current version pinning is restrictive and not necessary. As a result it's causing some version conflicts with other gems.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

#### Purpose

Provide more flexibility with json gem version

#### Known Compatablity Issues

None

