### PR TITLE
Support multiple outputs in Logstash handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
 notifications:
   email:
     recipients:
@@ -26,8 +26,8 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
     repo: sensu-plugins/sensu-plugins-logstash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
-- Added support to send to multiple endpoints
 - testing on ruby 2.3
 
-### Breaking change
+### Breaking Changes
 - dropped ruby 1.9 support
+- Added support to send to multiple endpoints
 
 ## [0.1.1] - 2017-03-15
 - changed json dependency from '= 1.8.3' to '< 2.0.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
 - Added support to send to multiple endpoints
+- testing on ruby 2.3
+
+### Breaking change
+- dropped ruby 1.9 support
 
 ## [0.1.1] - 2017-03-15
 - changed json dependency from '= 1.8.3' to '< 2.0.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Added support to send to multiple endpoints
 
 ## [0.1.1] - 2017-03-15
 - changed json dependency from '= 1.8.3' to '< 2.0.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [0.1.1] - 2017-03-15
+- changed json dependency from '= 1.8.3' to '< 2.0.0'
+
 ## [0.1.0] - 2016-08-10
 - changed sensu-plugin dependecy from `= 1.2.0` to `~> 1.2`
 - added TCP socket as an output option

--- a/README.md
+++ b/README.md
@@ -17,11 +17,20 @@
 ```
 {
   "logstash": {
-    "server": "redis.example.tld",
-    "port": 6379,
+    "endpoint": [
+      {
+        "address": "host1.example.tld",
+        "port": 5000,
+        "output": "redis"
+      },
+      {
+        "address": "host2.example.tld",
+        "port": 5001,
+        "output": "logstash"
+      }
+    ],
     "list": "logstash",
     "type": "sensu-logstash",
-    "output": "redis",
     "custom": {
       "thisFieldWillBeMergedIntoTheTopLevelOfOutgoingJSON": {
         "metadata": "some metadata",

--- a/sensu-plugins-logstash.gemspec
+++ b/sensu-plugins-logstash.gemspec
@@ -3,13 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
 
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-logstash'
-else
-  require_relative 'lib/sensu-plugins-logstash'
-end
-
-# pvt_key = '~/.ssh/gem-private_key.pem'
+require_relative 'lib/sensu-plugins-logstash'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu Plugins and contributors']
@@ -32,7 +26,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for working with logstash'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
There is a need to send Logstash events to more than one endpoint, this change will allow you to specify several different endpoints (Address, host, output type), all of which will be looped through and the event sent.

This is an alternative, hopefully more lightweight, method to having multiple logstash handlers running for every event, which could become quite resource intensive.

#### Known Compatablity Issues
Breaking change.
Logstash handler settings will require updating along with the gem, else the handler will fail.

