### PR TITLE
Add missing pipeline output duration metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
 - metrics-logstash-node.rb: Added missing pipeline output duration metric. (@Evesy)
 
 ## [1.2.0] - 2017-10-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- metrics-logstash-node.rb: Added missing pipeline output duration metric. (@Evesy)
 
 ## [1.2.0] - 2017-10-31
 ### Added

--- a/bin/metrics-logstash-node.rb
+++ b/bin/metrics-logstash-node.rb
@@ -136,6 +136,7 @@ class LogstashNodeMetrics < Sensu::Plugin::Metric::CLI::Graphite
       item['events'] = {} unless item.key?('events')
       metrics["pipeline.plugins.outputs.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
       metrics["pipeline.plugins.outputs.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
+      metrics["pipeline.plugins.outputs.#{item['id']}.events.duration_in_millis"] = item['events']['duration_in_millis'].to_i || 0
     end
 
     metrics.each do |k, v|

--- a/test/metrics-logstash_spec.rb
+++ b/test/metrics-logstash_spec.rb
@@ -29,4 +29,22 @@ describe 'MetricsLogstash', '#run' do
       /node01.logstash.pipeline.plugins.inputs.4a3d87d316c088c052271a51fae0e37f47a193b9-30.events.queue_push_duration_in_millis 1162712/
     ).to_stdout.and raise_error(SystemExit)
   end
+
+  it 'returns output duration data' do
+    stub_request(:get, /_node\/stats/)
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: File.new('test/fixtures/node_stats.json')
+      )
+    args = %w(--user foo --password bar --host localhost --port 4200 --scheme node01.logstash)
+
+    check = LogstashNodeMetrics.new(args)
+    expect { check.run }.to output(
+      /node01.logstash.pipeline.plugins.outputs.4a3d87d316c088c052271a51fae0e37f47a193b9-33.events.duration_in_millis 24613/
+    ).to_stdout.and raise_error(SystemExit)
+  end
 end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

metrics-logstash-node.rb does not currently collect metrics for Logstash output duration, only events in/out. This metric can prove useful for monitoring the performance of various Logstash outputs.

#### Known Compatablity Issues

n/a
