### PR TITLE
Added plugin name into plugin metrics

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 #### General
 
-- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
+- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 - [ ] Update README with any necessary configuration snippets
 
@@ -12,7 +12,7 @@
 
 - [ ] RuboCop passes
 
-- [ ] Existing tests pass 
+- [ ] Existing tests pass
 
 #### New Plugins
 
@@ -25,4 +25,3 @@
 #### Purpose
 
 #### Known Compatablity Issues
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
+This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+### Changed
+- updated changelog guidelines location (@majormoses)
 
 ## [1.3.0] - 2017-11-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Breaking Changes
+- metrics-logstash-node.rb: Added plugin name into pipeline metrics
 
 ### Changed
 - updated changelog guidelines location (@majormoses)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Changes
+- metrics-logstash-node.rb: Added plugin name into pipeline metrics
 
 ## [1.2.0] - 2017-10-31
 ### Added

--- a/bin/metrics-logstash-node.rb
+++ b/bin/metrics-logstash-node.rb
@@ -119,24 +119,25 @@ class LogstashNodeMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     node['pipeline']['plugins']['inputs'].each do |item|
       item['events'] = {} unless item.key?('events')
-      metrics["pipeline.plugins.inputs.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
-      metrics["pipeline.plugins.inputs.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
-      metrics["pipeline.plugins.inputs.#{item['id']}.events.queue_push_duration_in_millis"] = item['events']['queue_push_duration_in_millis'].to_i || 0
+      metrics["pipeline.plugins.inputs.#{item['name']}.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
+      metrics["pipeline.plugins.inputs.#{item['name']}.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
+      metrics["pipeline.plugins.inputs.#{item['name']}.#{item['id']}.events.queue_push_duration_in_millis"] = \
+        item['events']['queue_push_duration_in_millis'].to_i || 0
     end
 
     node['pipeline']['plugins']['filters'].each do |item|
       item['events'] = {} unless item.key?('events')
-      metrics["pipeline.plugins.filters.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
-      metrics["pipeline.plugins.filters.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
-      metrics["pipeline.plugins.filters.#{item['id']}.events.duration_in_millis"] = item['events']['duration_in_millis'].to_i || 0
-      metrics["pipeline.plugins.filters.#{item['id']}.matches"] = item['matches'].to_i if item.key?('matches')
+      metrics["pipeline.plugins.filters.#{item['name']}.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
+      metrics["pipeline.plugins.filters.#{item['name']}.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
+      metrics["pipeline.plugins.filters.#{item['name']}.#{item['id']}.events.duration_in_millis"] = item['events']['duration_in_millis'].to_i || 0
+      metrics["pipeline.plugins.filters.#{item['name']}.#{item['id']}.matches"] = item['matches'].to_i if item.key?('matches')
     end
 
     node['pipeline']['plugins']['outputs'].each do |item|
       item['events'] = {} unless item.key?('events')
-      metrics["pipeline.plugins.outputs.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
-      metrics["pipeline.plugins.outputs.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
-      metrics["pipeline.plugins.outputs.#{item['id']}.events.duration_in_millis"] = item['events']['duration_in_millis'].to_i || 0
+      metrics["pipeline.plugins.outputs.#{item['name']}.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
+      metrics["pipeline.plugins.outputs.#{item['name']}.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
+      metrics["pipeline.plugins.outputs.#{item['name']}.#{item['id']}.events.duration_in_millis"] = item['events']['duration_in_millis'].to_i || 0
     end
 
     metrics.each do |k, v|

--- a/bin/metrics-logstash-node.rb
+++ b/bin/metrics-logstash-node.rb
@@ -119,23 +119,24 @@ class LogstashNodeMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     node['pipeline']['plugins']['inputs'].each do |item|
       item['events'] = {} unless item.key?('events')
-      metrics["pipeline.plugins.inputs.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
-      metrics["pipeline.plugins.inputs.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
-      metrics["pipeline.plugins.inputs.#{item['id']}.events.queue_push_duration_in_millis"] = item['events']['queue_push_duration_in_millis'].to_i || 0
+      metrics["pipeline.plugins.inputs.#{item['name']}.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
+      metrics["pipeline.plugins.inputs.#{item['name']}.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
+      metrics["pipeline.plugins.inputs.#{item['name']}.#{item['id']}.events.queue_push_duration_in_millis"] = \
+        item['events']['queue_push_duration_in_millis'].to_i || 0
     end
 
     node['pipeline']['plugins']['filters'].each do |item|
       item['events'] = {} unless item.key?('events')
-      metrics["pipeline.plugins.filters.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
-      metrics["pipeline.plugins.filters.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
-      metrics["pipeline.plugins.filters.#{item['id']}.events.duration_in_millis"] = item['events']['duration_in_millis'].to_i || 0
-      metrics["pipeline.plugins.filters.#{item['id']}.matches"] = item['matches'].to_i if item.key?('matches')
+      metrics["pipeline.plugins.filters.#{item['name']}.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
+      metrics["pipeline.plugins.filters.#{item['name']}.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
+      metrics["pipeline.plugins.filters.#{item['name']}.#{item['id']}.events.duration_in_millis"] = item['events']['duration_in_millis'].to_i || 0
+      metrics["pipeline.plugins.filters.#{item['name']}.#{item['id']}.matches"] = item['matches'].to_i if item.key?('matches')
     end
 
     node['pipeline']['plugins']['outputs'].each do |item|
       item['events'] = {} unless item.key?('events')
-      metrics["pipeline.plugins.outputs.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
-      metrics["pipeline.plugins.outputs.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
+      metrics["pipeline.plugins.outputs.#{item['name']}.#{item['id']}.events.in"] = item['events']['in'].to_i || 0
+      metrics["pipeline.plugins.outputs.#{item['name']}.#{item['id']}.events.out"] = item['events']['out'].to_i || 0
     end
 
     metrics.each do |k, v|

--- a/test/metrics-logstash_spec.rb
+++ b/test/metrics-logstash_spec.rb
@@ -44,7 +44,7 @@ describe 'MetricsLogstash', '#run' do
 
     check = LogstashNodeMetrics.new(args)
     expect { check.run }.to output(
-      /node01.logstash.pipeline.plugins.outputs.elasticsearch4a3d87d316c088c052271a51fae0e37f47a193b9-33.events.duration_in_millis 24613/
+      /node01.logstash.pipeline.plugins.outputs.elasticsearch.4a3d87d316c088c052271a51fae0e37f47a193b9-33.events.duration_in_millis 24613/
     ).to_stdout.and raise_error(SystemExit)
   end
 end

--- a/test/metrics-logstash_spec.rb
+++ b/test/metrics-logstash_spec.rb
@@ -26,7 +26,7 @@ describe 'MetricsLogstash', '#run' do
 
     check = LogstashNodeMetrics.new(args)
     expect { check.run }.to output(
-      /node01.logstash.pipeline.plugins.inputs.4a3d87d316c088c052271a51fae0e37f47a193b9-30.events.queue_push_duration_in_millis 1162712/
+      /node01.logstash.pipeline.plugins.inputs.tcp.4a3d87d316c088c052271a51fae0e37f47a193b9-30.events.queue_push_duration_in_millis 1162712/
     ).to_stdout.and raise_error(SystemExit)
   end
 end

--- a/test/metrics-logstash_spec.rb
+++ b/test/metrics-logstash_spec.rb
@@ -26,7 +26,7 @@ describe 'MetricsLogstash', '#run' do
 
     check = LogstashNodeMetrics.new(args)
     expect { check.run }.to output(
-      /node01.logstash.pipeline.plugins.inputs.4a3d87d316c088c052271a51fae0e37f47a193b9-30.events.queue_push_duration_in_millis 1162712/
+      /node01.logstash.pipeline.plugins.inputs.tcp.4a3d87d316c088c052271a51fae0e37f47a193b9-30.events.queue_push_duration_in_millis 1162712/
     ).to_stdout.and raise_error(SystemExit)
   end
 
@@ -44,7 +44,7 @@ describe 'MetricsLogstash', '#run' do
 
     check = LogstashNodeMetrics.new(args)
     expect { check.run }.to output(
-      /node01.logstash.pipeline.plugins.outputs.4a3d87d316c088c052271a51fae0e37f47a193b9-33.events.duration_in_millis 24613/
+      /node01.logstash.pipeline.plugins.outputs.elasticsearch4a3d87d316c088c052271a51fae0e37f47a193b9-33.events.duration_in_millis 24613/
     ).to_stdout.and raise_error(SystemExit)
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

I'd like to add an additional dimension(?) into the generated name for plugin metrics in `metrics-logstash-node.rb` to make it easier to identify poor plugin performers/filter to them in dashboards etc.

Current pipeline plugin metrics are only identifiable by the ID, as per below, which is simply a unique identifier for the particular node, appended with an incrementing integer for each active plugin -- From this you are unable to determine which plugin relates to which metric:

`node01.logstash.pipeline.plugins.inputs.4a3d87d316c088c052271a51fae0e37f47a193b9-30.events.queue_push_duration_in_millis`

This proposed change adds the plugin name into the metric name, however still keeps the ID as the plugin name is unlikely to be unique:

`node01.logstash.pipeline.plugins.inputs.tcp.4a3d87d316c088c052271a51fae0e37f47a193b9-30.events.queue_push_duration_in_millis`

This allows you to filter down to specific plugins (i.e. a particular output type) to monitor plugins individually, however can easily be wild-carded to keep with current behaviour

#### Known Compatablity Issues

This will change the metric format for existing users which could affect anything that is querying this data.
