### PR TITLE
Readme: Fixed wrong output type in conf example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,14 @@
         "output": "redis"
       },
       {
-        "address": "host2.example.tld",
+        "address": "logstash-host1.example.tld",
         "port": 5001,
-        "output": "logstash"
+        "output": "udp"
+      },
+      {
+        "address": "logstash-host2.example.tld",
+        "port": 5002,
+        "output": "tcp"
       }
     ],
     "list": "logstash",


### PR DESCRIPTION
Supported output types for this plugin are: redis, tcp, udp
The example in Readme was showing an unsupported output type "logstash", which was confusing.
I have provided a valid configuration for logstash, using output type "udp" and "tcp".